### PR TITLE
Add visualization to preprocessing and sampling stages

### DIFF
--- a/channel_selection.py
+++ b/channel_selection.py
@@ -30,6 +30,9 @@ def run(config: dict) -> None:
     output_dir = os.path.join(params.output_dir, output_dir_name)
     os.makedirs(output_dir, exist_ok=True)
 
+    figure_root = os.path.join(output_dir, "figures")
+    os.makedirs(figure_root, exist_ok=True)
+
     update_configuration(
         output_path = os.path.join(output_dir, "config.yaml"),
         previous_config_path = os.path.join(params.sample_dir, "config.yaml"),
@@ -69,11 +72,11 @@ def run(config: dict) -> None:
                 )
 
             module_figure_dir = os.path.join(
-                params.figure_dir, selection_name, f'subject_{subject_id}'
+                figure_root, selection_name, f'subject_{subject_id}'
             )
             os.makedirs(module_figure_dir, exist_ok=True)
 
-            if hasattr(params, 'figure_dir') and hasattr(module, 'generate_figures'):
+            if hasattr(module, 'generate_figures'):
                 module.generate_figures(
                     data, module_results, module_params,
                     figure_dir=module_figure_dir

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -7,9 +7,8 @@ from utils.config import load_config
 
 STAGES = [
     "preprocess",
-    "channel_selection_active",
-    "channel_selection_discriminative",
     "sample_collection",
+    "channel_selection",
     "training",
     "evaluation",
     "visualisation",


### PR DESCRIPTION
## Summary
- Save channel-selection figures next to JSON outputs
- Visualize random channel windows before and after each preprocessing step
- Illustrate event onsets vs offsets during sample extraction
- Update pipeline stages for new order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68945a822f548329a3f95d39649cca72