### PR TITLE
Refactor preprocessing into modular multi-modal pipeline

### DIFF
--- a/data_loading/io_tdt.py
+++ b/data_loading/io_tdt.py
@@ -1,36 +1,32 @@
 import os
+import numpy as np
 import tdt
 
-def get_data(data_path: str) -> dict:
-    """
-    Read a TDT block and return the data as a dictionary.
-    """
 
-    block_data = tdt.read_block(data_path)
-
+def load_block(block_path: str) -> dict:
+    """Read a TDT block and return the data as a dictionary."""
+    block_data = tdt.read_block(block_path)
     data = {
-        'ecog': block_data.streams.EOG1.data,
-        'audio': block_data.streams.ANIN.data[:1, :],  # mono-channel audio
-        'ecog_sf': block_data.streams.EOG1.fs,
-        'audio_sf': block_data.streams.ANIN.fs
+        "ecog": block_data.streams.EOG1.data,
+        "audio": block_data.streams.ANIN.data[:1, :],
+        "ecog_sf": block_data.streams.EOG1.fs,
+        "audio_sf": block_data.streams.ANIN.fs,
     }
-
     for key, value in data.items():
-        if not key.endswith('sf'):
-            print(f'Shape of {key}: ', value.shape)
-
+        if not key.endswith("sf"):
+            print(f"Shape of {key}: ", value.shape)
     return data
 
 
-def get_block_id(data_path: str) -> str:
-    """
-    Extract the block ID from the data path.
-    """
-    try:
-        return int(dir.split('-')[-1].replace('B', ''))
-    except ValueError:
-        print(
-            f"Skipping directory '{data_path}' as it does not match expected format.",
-            "Expected format: 'HS<subject_id>-<block_id>'.",
-        )
-        return None
+def save_block(setup_dir: str, subject_id: int, block_id: int, data_dict: dict) -> None:
+    """Save all modalities in a block to disk."""
+    subject_output_dir = os.path.join(setup_dir, f"subject_{subject_id}")
+    os.makedirs(subject_output_dir, exist_ok=True)
+
+    for key, value in data_dict.items():
+        if key.endswith("_sf"):
+            continue
+        sf = data_dict.get(f"{key}_sf")
+        file_path = os.path.join(subject_output_dir, f"B{block_id}_{key}.npz")
+        np.savez(file_path, data=value, sf=sf)
+        print(f"Saved {key} data to: {file_path}")

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -5,33 +5,46 @@ dataset:
 preprocess:
   module: preprocess_main
   params:
+    pipeline:
+      module: preprocess.pipelines.subject_block
+      params:
+        subject_dirs:
+          - Sub1/tdt
+          - Sub2/tdt
+        subject_ids: [1, 2]
     io:
-      root_dir: data/raw
-      subject_dirs:
-        - Sub1/tdt
-        - Sub2/tdt
-      subject_ids: [1, 2]                    # Subject IDs for naming files
-      output_dir: data/processed
-    steps:
-      - module: preproccess.downsample
-        params:
-          downsample_freq: 400
-      
-      - module: preproccess.frequency_filter
-        params:
-          bands:
-          - method: hilbert
-            params:
-              freq_ranges: [70, 150]
-              envelope: true
-          - method: butter
-            params:
-              freqs: [0.3, 100]
-              filter_type: bandpass
+      module: data_loading.io_tdt
+      params:
+        root_dir: data/raw
+        output_dir: data/processed
+    preprocessor:
+      module: preprocess.preprocessor
+    modalities:
+      ecog:
+        type: signal
+        preprocessing:
+          steps:
+            - module: preprocess.downsample
+              params:
+                downsample_freq: 400
 
-      - module: preproccess.zscore_rereference
-        params:
-          rereference_interval: [0., 25.]   # Interval in seconds for rereferencing
+            - module: preprocess.frequency_filter
+              params:
+                bands:
+                  - method: hilbert
+                    params:
+                      freq_ranges: [70, 150]
+                      envelope: true
+                  - method: butter
+                    params:
+                      freqs: [0.3, 100]
+                      filter_type: bandpass
+
+            - module: preprocess.zscore_rereference
+              params:
+                rereference_interval: [0., 25.]
+      audio:
+        type: signal
 
 sample_collection:
   module: extract_samples

--- a/preprocess/pipelines/subject_block.py
+++ b/preprocess/pipelines/subject_block.py
@@ -1,0 +1,95 @@
+import os
+import yaml
+import hashlib
+from typing import Dict, Any
+
+from utils.config import dict_to_namespace
+
+
+def get_block_id(dirname: str) -> int:
+    """Extract the block ID from a directory name."""
+    try:
+        return int(dirname.split('-')[-1].replace('B', ''))
+    except ValueError:
+        print(
+            f"Skipping directory '{dirname}' as it does not match expected format.",
+            "Expected format: 'HS<subject_id>-<block_id>'.",
+        )
+        return None
+
+
+def iter_blocks(root_dir: str, subject_dirs, subject_ids=None):
+    """Yield (subject_id, block_id, block_path) tuples."""
+    if subject_ids is None:
+        subject_ids = [i + 1 for i in range(len(subject_dirs))]
+
+    for subject_id, subject_dir in zip(subject_ids, subject_dirs):
+        subject_path = os.path.join(root_dir, subject_dir)
+        for dir_name in os.listdir(subject_path):
+            block_id = get_block_id(dir_name)
+            if block_id is None:
+                continue
+            block_path = os.path.join(subject_path, dir_name)
+            yield subject_id, block_id, block_path
+
+
+def generate_setup_name(modalities_cfg: Dict[str, Any]) -> str:
+    steps = []
+    for mod_cfg in modalities_cfg.values():
+        steps.extend(mod_cfg.get("preprocessing", {}).get("steps", []))
+    readable_parts = [step["module"].split(".")[-1] for step in steps]
+    readable_name = "__".join(readable_parts) if readable_parts else "raw"
+    setup_str = "_".join([f"{step['module']}_{step.get('params', {})}" for step in steps])
+    hash_part = hashlib.md5(setup_str.encode()).hexdigest()[:6]
+    return f"{readable_name}_{hash_part}" if readable_parts else readable_name
+
+
+def run(pipeline_params, io_params, io_module, preprocessor_module, modalities_cfg):
+    setup_name = generate_setup_name(modalities_cfg)
+    setup_dir = os.path.join(io_params.output_dir, setup_name)
+    os.makedirs(setup_dir, exist_ok=True)
+
+    figure_root = os.path.join(setup_dir, "figures")
+    os.makedirs(figure_root, exist_ok=True)
+
+    config_path = os.path.join(setup_dir, "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.dump(
+            {
+                "pipeline": vars(pipeline_params),
+                "io": vars(io_params),
+                "modalities": modalities_cfg,
+            },
+            f,
+        )
+
+    for subject_id, block_id, block_path in iter_blocks(
+        io_params.root_dir,
+        pipeline_params.subject_dirs,
+        getattr(pipeline_params, "subject_ids", None),
+    ):
+        print(f"Processing block {block_id} of subject {subject_id}...")
+
+        data_dict = io_module.load_block(block_path)
+
+        block_params = dict_to_namespace(
+            {
+                **vars(io_params),
+                "block_id": block_id,
+                "subject_id": subject_id,
+            },
+            exclude_keys=["root_dir", "output_dir"],
+        )
+
+        block_figure_dir = os.path.join(
+            figure_root, f"subject_{subject_id}", f"block_{block_id}"
+        )
+        os.makedirs(block_figure_dir, exist_ok=True)
+
+        preprocessor_module.preprocess_modalities(
+            data_dict, modalities_cfg, block_params, figure_dir=block_figure_dir
+        )
+
+        io_module.save_block(setup_dir, subject_id, block_id, data_dict)
+
+    return setup_dir

--- a/preprocess/preprocessor.py
+++ b/preprocess/preprocessor.py
@@ -1,0 +1,136 @@
+import os
+import importlib
+from copy import deepcopy
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+
+def preprocess_modalities(data_dict, modalities_cfg, base_params, figure_dir=None):
+    """Preprocess each modality according to its type and configured steps."""
+    for modality, cfg in modalities_cfg.items():
+        mod_type = cfg.get("type")
+        if mod_type is None:
+            raise KeyError(f"Modality '{modality}' missing 'type' field in config")
+        if mod_type != "signal":
+            raise NotImplementedError(
+                f"Modality type '{mod_type}' not supported; currently only 'signal'"
+            )
+
+        steps = cfg.get("preprocessing", {}).get("steps", [])
+        if not steps:
+            continue
+
+        params = deepcopy(base_params)
+        params.signal_freq = data_dict.get(f"{modality}_sf")
+        mod_fig_dir = os.path.join(figure_dir, modality) if figure_dir else None
+
+        processed, freq = preprocess_signal(
+            data_dict[modality], steps, params, figure_dir=mod_fig_dir
+        )
+        data_dict[modality] = processed
+        if freq is not None:
+            data_dict[f"{modality}_sf"] = freq
+
+    return data_dict
+
+
+# TODO - this function does not visualise steps where number of channels change.
+def preprocess_signal(data, steps, block_params, figure_dir=None,
+                      num_channels=5, duration=1.0):
+    """Apply preprocessing steps sequentially to the data."""
+    for i, step in enumerate(steps):
+        module_name = step['module']
+        step_params = step.get('params', {})
+
+        for key, value in step_params.items():
+            if hasattr(block_params, key):
+                raise ValueError(
+                    f"Parameter '{key}' already exists in params. "
+                    "Please ensure no conflicting parameter names "
+                    "in each preprocessing step."
+                )
+            setattr(block_params, key, value)
+
+        before_data = data.copy()
+        before_freq = block_params.signal_freq
+
+        module = importlib.import_module(module_name)
+        data = module.run(data, block_params)
+
+        if figure_dir and data.ndim == 2:
+            visualise_preprocessing(
+                before_data, before_freq, data,
+                block_params, figure_dir,
+                i, module_name,
+                num_channels=num_channels,
+                duration=duration
+            )
+
+    return data, block_params.signal_freq
+
+
+def visualise_preprocessing(
+    before_data: np.ndarray,
+    before_freq: float,
+    after_data: np.ndarray,
+    block_params: object,
+    block_figure_dir: str,
+    step_index: int,
+    module_name: str,
+    num_channels: int,
+    duration: float,
+) -> None:
+    """Visualize the effect of preprocessing on multiple channels."""
+    after_freq = block_params.signal_freq
+
+    max_time = min(
+        before_data.shape[1] / before_freq,
+        after_data.shape[1] / after_freq,
+    )
+    duration = min(duration, max_time)
+    start_time = np.random.uniform(0, max_time - duration)
+    end_time = start_time + duration
+
+    fig, ax = plt.subplots(num_channels, 1, figsize=(10, 4 * num_channels), sharex=True)
+    if num_channels == 1:
+        ax = [ax]  # Ensure ax is iterable for a single channel
+
+    for i in range(num_channels):
+        ch_idx = np.random.randint(0, before_data.shape[0])
+        before_slice = before_data[
+            ch_idx,
+            int(start_time * before_freq):int(end_time * before_freq),
+        ]
+        after_slice = after_data[
+            ch_idx,
+            int(start_time * after_freq):int(end_time * after_freq),
+        ]
+        time_before = np.linspace(
+            start_time, end_time, before_slice.shape[0], endpoint=False
+        )
+        time_after = np.linspace(
+            start_time, end_time, after_slice.shape[0], endpoint=False
+        )
+
+        ax[i].plot(time_before, before_slice, label="before", alpha=0.7)
+        ax[i].plot(time_after, after_slice, label="after", alpha=0.7)
+        ax[i].set_title(f"Channel {ch_idx}", fontsize=18)
+        ax[i].set_ylabel("Amplitude", fontsize=14)
+        ax[i].legend(fontsize=12)
+
+    ax[-1].set_xlabel("Time (s)", fontsize=14)
+    fig.suptitle(
+        f"{module_name.split('.')[-1]} - Preprocessing Step {step_index + 1}",
+        fontsize=20,
+    )
+
+    fig.tight_layout()
+    fig.subplots_adjust(top=0.9)
+
+    fig_path = os.path.join(
+        block_figure_dir,
+        f"step{step_index + 1}_{module_name.split('.')[-1]}.png",
+    )
+    fig.savefig(fig_path, dpi=500)
+    plt.close(fig)

--- a/preprocess_main.py
+++ b/preprocess_main.py
@@ -1,272 +1,32 @@
-"""
-Extract ECoG signal from TDT blocks, preprocess, and save to .npz files.
+"""Entry point for configurable preprocessing pipelines."""
 
-This script now reads its parameters from a YAML configuration file.
-
-Structure of the output directory:
-processed/
-├── setup_1/
-|   ├── config.yaml
-│   ├── subject_1/
-│   │   ├── B1_ecog.npz
-│   │   ├── B1_sound.npz
-│   │   ├── ...
-│   ├── subject_2/
-│   │   ├── B1_ecog.npz
-│   │   ├── B1_sound.npz
-│   │   ├── ...
-├── setup_2/
-|   ├── config.yaml
-│   ├── subject_1/
-│   │   ├── B1_ecog.npz
-│   │   ├── B1_sound.npz
-│   │   ├── ...
-│   ├── subject_2/
-│   │   ├── B1_ecog.npz
-│   │   ├── B1_sound.npz
-│   │   ├── ...
-where B stands for block / trial.
-Set up name will be generated based on the preprocessing steps:
-# step1__step2__step3_<hash>
-"""
-
-import os
-import tdt
-import numpy as np
-import yaml
 import importlib
-import hashlib
-import matplotlib.pyplot as plt
-
-from utils.config import dict_to_namespace
-from data_loading.io_tdt import get_data, get_block_id
+import sys
+from utils.config import load_config, dict_to_namespace
 
 
-def run(config: dict) -> str:
-    """Extract and preprocess ECoG signals based on configuration."""
+def main(config_path: str) -> None:
+    cfg = load_config(config_path)
+    pre_cfg = cfg.get("preprocess", {}).get("params", {})
 
-    pre_cfg = config.get("preprocess", {})
-    pre_params = pre_cfg.get("params", {})
-    io_cfg = pre_params.get("io", {})
+    pipeline_cfg = pre_cfg.get("pipeline", {})
+    io_cfg = pre_cfg.get("io", {})
+    preprocessor_cfg = pre_cfg.get("preprocessor", {"module": "preprocess.preprocessor"})
+    modalities_cfg = pre_cfg.get("modalities", {})
 
-    params = dict_to_namespace(io_cfg)
+    pipeline_module = importlib.import_module(pipeline_cfg.get("module"))
+    preprocessor_module = importlib.import_module(preprocessor_cfg.get("module"))
+    io_module = importlib.import_module(io_cfg.get("module"))
 
-    os.makedirs(params.output_dir, exist_ok=True)
+    pipeline_params = dict_to_namespace(pipeline_cfg.get("params", {}))
+    io_params = dict_to_namespace(io_cfg.get("params", {}))
 
-    setup_name = generate_setup_name(pre_cfg)
-    setup_dir = os.path.join(params.output_dir, setup_name)
-    os.makedirs(setup_dir, exist_ok=True)
-
-    figure_root = os.path.join(setup_dir, 'figures')
-    os.makedirs(figure_root, exist_ok=True)
-
-    # Save the configuration used for this setup
-    config_file_path = os.path.join(setup_dir, 'config.yaml')
-    pre_configs = {'preprocess': pre_cfg}
-    with open(config_file_path, 'w') as f:
-        yaml.dump(pre_configs, f)
-
-    if not hasattr(params, 'subject_ids'):
-        params.subject_ids = [
-            i+1 for i in range(len(params.subject_dirs))
-        ]
-
-    for subject_id, subject_dir in zip(params.subject_ids, params.subject_dirs):
-        subject_dir = os.path.join(params.root_dir, subject_dir)
-
-        for dir in os.listdir(subject_dir):
-            block_id = get_block_id(dir)
-
-            if block_id is None:
-                continue
-
-            print(f'Processing block {block_id} of subject {subject_id}...')
-
-            ecog_file_name = f'B{block_id}_ecog.npz'
-            audio_file_name = f'B{block_id}_sound.npz'
-
-            subject_output_dir = os.path.join(setup_dir, f"subject_{subject_id}")
-            os.makedirs(subject_output_dir, exist_ok=True)
-
-            ecog_file = os.path.join(subject_output_dir, ecog_file_name)
-            audio_file = os.path.join(subject_output_dir, audio_file_name)
-
-            block_figure_dir = os.path.join(
-                figure_root, f'subject_{subject_id}', f'block_{block_id}'
-            )
-            os.makedirs(block_figure_dir, exist_ok=True)
-
-            if os.path.exists(ecog_file) and os.path.exists(audio_file):
-                print(f'Skipping block {block_id}, already processed.')
-                continue
-
-            block_path = os.path.join(subject_dir, dir)
-
-            data_dict = get_data(block_path)
-
-            data = data_dict['ecog']
-
-            block_params = dict_to_namespace(
-                {
-                    **vars(params),
-                    'block_id': block_id,
-                    'subject_id': subject_id,
-                    'signal_freq': data_dict['fs_ecog']
-                },
-                exclude_keys=['bands']
-            )
-
-            for i, step in enumerate(pre_params.get('steps', [])):
-                module_name = step['module']
-                step_params = step.get('params', {})
-
-                for key, value in step_params.items():
-                    if hasattr(block_params, key):
-                        raise ValueError(
-                            f"Parameter '{key}' already exists in params. "
-                            "Please ensure no conflicting parameter names"
-                            " in each preprocessing step."
-                        )
-
-                    setattr(block_params, key, value)
-
-                before_data = data.copy()
-                before_freq = block_params.signal_freq
-
-                module = importlib.import_module(module_name)
-                data = module.run(data, block_params)
-
-                if data.ndim == 2:
-                    visualise_preprocessing(
-                        before_data, before_freq, data,
-                        block_params, block_figure_dir,
-                        i, module_name,
-                        num_channels=5,
-                        duration=1.0
-                    )
-
-            if not os.path.exists(ecog_file):
-                np.savez(
-                    ecog_file, data=data,
-                    sf=block_params.signal_freq
-                )
-                print('Saved ECoG data to:', ecog_file)
-            else:
-                print('ECoG data already exists:', ecog_file)
-
-            if not os.path.exists(audio_file):
-                np.savez(
-                    audio_file, data=data_dict['audio'],
-                    sf=int(data_dict['audio_sf'])
-                )
-                print('Saved audio data to:', audio_file)
-            else:
-                print('Audio data already exists:', audio_file)
-
-    return setup_dir
-
-
-def generate_setup_name(pre_cfg: dict) -> str:
-    """Generate a unique name for the preprocessing setup based on the configuration."""
-    steps = pre_cfg.get("params", {}).get("steps", [])
-
-    readable_parts = [
-        step["module"].split(".")[-1] for step in steps
-    ]
-    readable_name = "__".join(readable_parts)
-
-    setup_str = "_".join([f"{step['module']}_{step['params']}" for step in steps])
-    hash_part = hashlib.md5(setup_str.encode()).hexdigest()[:6]
-
-    # ensure uniqueness and avoid overly long names
-    return f"{readable_name}_{hash_part}"
-
-
-# TODO - this function does not visualise steps where number of channels change.
-def visualise_preprocessing(
-    before_data: np.ndarray,
-    before_freq: float,
-    after_data: np.ndarray,
-    block_params: object,
-    block_figure_dir: str,
-    step_index: int,
-    module_name: str,
-    num_channels: int,
-    duration: float
-) -> None:
-    """
-    Visualize the effect of preprocessing on multiple channels.
-
-    Args:
-        before_data (np.ndarray): Data before preprocessing (channels x timepoints).
-        after_data (np.ndarray): Data after preprocessing (channels x timepoints).
-        block_params (object): Block parameters containing sampling frequency.
-        block_figure_dir (str): Directory to save the figure.
-        step_index (int): Index of the preprocessing step.
-        module_name (str): Name of the preprocessing module.
-        num_channels (int): Number of random channels to plot.
-        duration (float): Duration of the signal to plot (in seconds).
-    """
-    after_freq = block_params.signal_freq
-
-    max_time = min(
-        before_data.shape[1] / before_freq,
-        after_data.shape[1] / after_freq
+    pipeline_module.run(
+        pipeline_params, io_params, io_module, preprocessor_module, modalities_cfg
     )
-    duration = min(duration, max_time)
-    start_time = np.random.uniform(0, max_time - duration)
-    end_time = start_time + duration
-
-    fig, ax = plt.subplots(num_channels, 1, figsize=(10, 4 * num_channels), sharex=True)
-    if num_channels == 1:
-        ax = [ax]  # Ensure ax is iterable for a single channel
-
-    for i in range(num_channels):
-        ch_idx = np.random.randint(0, before_data.shape[0])
-        before_slice = before_data[
-            ch_idx,
-            int(start_time * before_freq):int(end_time * before_freq)
-        ]
-        after_slice = after_data[
-            ch_idx,
-            int(start_time * after_freq):int(end_time * after_freq)
-        ]
-        time_before = np.linspace(
-            start_time, end_time, before_slice.shape[0], endpoint=False
-        )
-        time_after = np.linspace(
-            start_time, end_time, after_slice.shape[0], endpoint=False
-        )
-
-        ax[i].plot(time_before, before_slice, label='before', alpha=0.7)
-        ax[i].plot(time_after, after_slice, label='after', alpha=0.7)
-        ax[i].set_title(f'Channel {ch_idx}', fontsize=18)
-        ax[i].set_ylabel('Amplitude', fontsize=14)
-        ax[i].legend(fontsize=12)
-
-    ax[-1].set_xlabel('Time (s)', fontsize=14)
-    fig.suptitle(
-        f'{module_name.split(".")[-1]} - Preprocessing Step {step_index + 1}',
-        fontsize=20
-    )
-
-    fig.tight_layout()
-    fig.subplots_adjust(top=0.9)
-
-    fig_path = os.path.join(
-        block_figure_dir,
-        f'step{step_index + 1}_{module_name.split(".")[-1]}.png'
-    )
-    fig.savefig(fig_path, dpi=500)
-    plt.close(fig)
-
 
 
 if __name__ == "__main__":
-    import sys
-    from utils.config import load_config
-
     if len(sys.argv) != 2:
-        raise SystemExit("Usage: python preprocess.py <config.yaml>")
-    cfg = load_config(sys.argv[1])
-    run(cfg)
+        raise SystemExit("Usage: python preprocess_main.py <config.yaml>")
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- Load pipeline, I/O, and preprocessing modules dynamically via importlib
- Move subject-block iteration into a dedicated pipeline plugin with I/O-managed saving
- Support modality-specific preprocessing steps and configuration structure
- Validate modality types during preprocessing, currently handling only signal data

## Testing
- `python -m py_compile preprocess_main.py preprocess/preprocessor.py preprocess/pipelines/subject_block.py data_loading/io_tdt.py`


------
https://chatgpt.com/codex/tasks/task_e_689ee05e4e7c83298ef5a4aebcd9ed14