### PR TITLE
Add paired onset/pre-onset sampling and channel significance test

### DIFF
--- a/channel_selection/paired_onset_pre.py
+++ b/channel_selection/paired_onset_pre.py
@@ -1,0 +1,142 @@
+"""Channel selection based on paired speech onset and pre-onset signals."""
+
+import numpy as np
+from typing import Optional
+from scipy.stats import ttest_rel
+import matplotlib.pyplot as plt
+import os
+import random
+
+from .utils import get_max_length
+
+
+def run(data: dict, params: dict) -> dict:
+    """Identify channels with significant onset vs pre-onset difference."""
+    onset_name = params.get('onset_name', 'ecog_onset')
+    pre_name = params.get('pre_name', 'ecog_pre')
+
+    try:
+        ecog_sf = data['ecog_sf']
+    except KeyError:
+        raise ValueError('ECoG sampling frequency (ecog_sf) not found in data.')
+
+    try:
+        onset_samples = data[onset_name]
+        pre_samples = data[pre_name]
+    except KeyError as e:
+        raise KeyError(
+            f"Recording '{e.args[0]}' not found in data. Available keys: {list(data.keys())}")
+
+    if onset_samples.shape != pre_samples.shape:
+        raise ValueError(
+            f"Shape mismatch between '{onset_name}' and '{pre_name}': "
+            f"{onset_samples.shape} vs {pre_samples.shape}.")
+
+    n_channels = onset_samples.shape[1]
+    corrected_p = params['p_threshold'] / onset_samples.shape[2]
+    length_threshold = int(params['active_time_threshold'] * ecog_sf)
+
+    selected = []
+    lengths = []
+    p_all = []
+
+    for ch in range(n_channels):
+        onset_data = onset_samples[:, ch, :]
+        pre_data = pre_samples[:, ch, :]
+        _, p_vals = ttest_rel(onset_data, pre_data, axis=0)
+        p_all.append(p_vals)
+        significant = np.where(p_vals < corrected_p)[0]
+        if len(significant) == 0:
+            continue
+        max_len = get_max_length(significant)
+        if max_len > length_threshold:
+            selected.append(ch)
+            lengths.append(max_len)
+
+    print(f"Found {len(selected)} active channels.")
+    return {
+        'selected_channels': selected,
+        'max_lengths': lengths,
+        'p_values': p_all,
+    }
+
+
+def generate_figures(data: dict, results: dict, params: dict, figure_dir: str) -> None:
+    ecog_sf = data['ecog_sf']
+    lengths = results['max_lengths']
+    channels = results['selected_channels']
+    p_vals = results['p_values']
+
+    figure_path = os.path.join(figure_dir, 'active_lengths.png')
+    plt.figure(figsize=(10,6))
+    lengths_sec = np.array(lengths) / ecog_sf
+    if len(lengths_sec) > 0:
+        plt.hist(lengths_sec, bins=30, alpha=0.7, color='blue')
+    plt.title('Distribution of Active Length of Significant Channels', fontsize=18)
+    plt.xlabel('Active length (s)', fontsize=16)
+    plt.ylabel('Frequency', fontsize=16)
+    plt.savefig(figure_path, dpi=400)
+    plt.close()
+    print(f"Saved distribution of lengths of significant channels to {figure_path}")
+
+    n_channels_plot = min(10, len(channels))
+    if n_channels_plot == 0:
+        return
+    selected_channels = random.sample(channels, n_channels_plot)
+    for ch in selected_channels:
+        fig_name = f"channel_{ch}_pre_onset.png"
+        path = os.path.join(figure_dir, fig_name)
+        plot_pre_onset(
+            data[params.get('pre_name', 'ecog_pre')][:, ch, :],
+            data[params.get('onset_name', 'ecog_onset')][:, ch, :],
+            p_vals=p_vals[ch],
+            p_val_threshold=params['p_threshold'],
+            sampling_rate=ecog_sf,
+            figure_path=path,
+        )
+
+
+def plot_pre_onset(
+        pre_data: np.ndarray,
+        onset_data: np.ndarray,
+        p_vals: np.ndarray,
+        p_val_threshold: float = 0.05,
+        sampling_rate: int = 400,
+        figure_path: Optional[str] = None,
+    ) -> None:
+    """Plot pre-onset vs onset activity for a channel."""
+
+    if pre_data.shape[1] != onset_data.shape[1]:
+        raise ValueError('Pre-onset and onset data must have same number of timepoints.')
+
+    n_timepoints = pre_data.shape[1]
+    pre_mean = pre_data.mean(axis=0)
+    pre_sem = pre_data.std(axis=0) / np.sqrt(pre_data.shape[0])
+    onset_mean = onset_data.mean(axis=0)
+    onset_sem = onset_data.std(axis=0) / np.sqrt(onset_data.shape[0])
+    time = np.linspace(0, n_timepoints / sampling_rate, n_timepoints)
+
+    fig, axes = plt.subplots(1, 2, figsize=(16,6))
+    axes[0].plot(time, pre_mean, label='Pre-onset Mean ± SEM', color='blue')
+    axes[0].fill_between(time, pre_mean - pre_sem, pre_mean + pre_sem, color='blue', alpha=0.2)
+    axes[0].plot(time, onset_mean, label='Onset Mean ± SEM', color='orange')
+    axes[0].fill_between(time, onset_mean - onset_sem, onset_mean + onset_sem, color='orange', alpha=0.2)
+    axes[0].set_title('Comparison of Pre-onset and Onset Activity', fontsize=16)
+    axes[0].set_xlabel('Time (s)', fontsize=14)
+    axes[0].set_ylabel('Amplitude', fontsize=14)
+    axes[0].legend()
+    axes[0].grid(True)
+
+    axes[1].plot(time, p_vals, label='P-values', color='red')
+    axes[1].axhline(y=p_val_threshold, color='black', linestyle='--')
+    axes[1].set_title('Paired t-test p-values', fontsize=16)
+    axes[1].set_xlabel('Time (s)', fontsize=14)
+    axes[1].set_ylabel('p-value', fontsize=14)
+    axes[1].set_ylim(0, 1)
+    axes[1].grid(True)
+
+    if figure_path is None:
+        plt.show()
+    else:
+        plt.savefig(figure_path, dpi=400)
+        plt.close()

--- a/sample_collection/pairwise_samples_ecog_audio.py
+++ b/sample_collection/pairwise_samples_ecog_audio.py
@@ -1,0 +1,199 @@
+"""Extract speech onset and pre-onset ECoG and audio samples."""
+
+import pandas as pd
+import numpy as np
+import os
+from typing import Dict
+from argparse import Namespace
+import warnings
+
+from .utils import extract_block_id, match_filename
+from .samples_ecog_audio import generate_figures
+
+
+def get_samples(intervals: Dict[int, pd.DataFrame], params: Namespace) -> Dict[str, np.ndarray]:
+    """Extract paired speech-onset and pre-onset samples.
+
+    Parameters
+    ----------
+    intervals : Dict[int, pd.DataFrame]
+        Mapping from block id to DataFrame of intervals with columns
+        'start' and 'end'.
+    params : Namespace
+        Expected fields:
+            - sample_length: float, length of onset sample in seconds.
+            - max_pre_length: float, maximum length for pre-onset sample in seconds.
+            - recording_format: str, file extension of recordings (default '.npz').
+            - onset_position: str, either 'start' or 'end' indicating where
+              speech onset is referenced in the interval (default 'start').
+            - output_path: optional, path to save resulting npz.
+            - data_dir: directory containing processed recordings.
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        Contains keys 'ecog_onset', 'ecog_pre', 'ecog_sf',
+        'audio_onset', 'audio_pre', 'audio_sf',
+        'syllable', 'tone'.
+    """
+    sample_length = getattr(params, 'sample_length', 1.0)
+    pre_length = getattr(params, 'max_pre_length', sample_length)
+    recording_format = getattr(params, 'recording_format', '.npz')
+    onset_pos = getattr(params, 'onset_position', 'start')
+
+    generate_figures(
+        intervals,
+        params.data_dir,
+        figure_dir=os.path.join(os.path.dirname(params.output_path), 'figures'),
+        subject_id=params.subject_id,
+    )
+
+    ecog_onset = {}
+    ecog_pre = {}
+    audio_onset = {}
+    audio_pre = {}
+    syllable_labels = {}
+    tone_labels = {}
+
+    syllables = getattr(params, 'syllable_identifiers', None)
+    if syllables is None:
+        syllables = sorted({
+            s for df in intervals.values() for s in df.get('syllable', [])
+        })
+    print('Syllable mapping used: ', dict(enumerate(syllables)), flush=True)
+
+    for file in os.listdir(params.data_dir):
+        if match_filename(file, recording_format, ['ecog']):
+            block = extract_block_id(file)
+            if block not in intervals:
+                continue
+            if block in ecog_onset:
+                warnings.warn(
+                    f'Found multiple ECoG files for block {block}, skipping {file}.')
+                continue
+            file_path = os.path.join(params.data_dir, file)
+            dataset = np.load(file_path)
+            try:
+                ecog_data = dataset['data']
+                ecog_sf = int(dataset['sf'])
+            except KeyError:
+                raise KeyError(
+                    f"Expected keys 'data' and 'sf' not found in {file}. "
+                    f"Existing keys {list(dataset.keys())}.")
+
+            block_intervals = intervals[block]
+            required_cols = {'start', 'end', 'syllable', 'tone'}
+            if not required_cols.issubset(block_intervals.columns):
+                raise ValueError(
+                    f"Intervals for block {block} must contain columns {required_cols}. "
+                    f"Available: {list(block_intervals.columns)}")
+            block_intervals = block_intervals.sort_values('start').reset_index(drop=True)
+            ecog_onset[block] = []
+            ecog_pre[block] = []
+            prev_end = 0.0
+            for _, row in block_intervals.iterrows():
+                onset_time = row[onset_pos]
+                start_idx = int(onset_time * ecog_sf)
+                length_idx = int(sample_length * ecog_sf)
+                end_idx = start_idx + length_idx
+                if end_idx > ecog_data.shape[1]:
+                    raise ValueError(
+                        f"Requested sample exceeds ECoG data for block {block}.")
+                ecog_onset[block].append(ecog_data[:, start_idx:end_idx])
+
+                pre_end = start_idx
+                pre_start_time = max(onset_time - pre_length, prev_end)
+                pre_start_idx = int(pre_start_time * ecog_sf)
+                pre_seg = ecog_data[:, pre_start_idx:pre_end]
+                desired = int(pre_length * ecog_sf)
+                if pre_seg.shape[1] < desired:
+                    pad = np.zeros((ecog_data.shape[0], desired - pre_seg.shape[1]))
+                    pre_seg = np.concatenate([pad, pre_seg], axis=1)
+                ecog_pre[block].append(pre_seg[:, -desired:])
+                prev_end = row['end']
+            ecog_onset[block] = np.array(ecog_onset[block])
+            ecog_pre[block] = np.array(ecog_pre[block])
+            tone_labels[block] = block_intervals['tone'].to_numpy()
+            syllable_categories = pd.Categorical(
+                block_intervals['syllable'], categories=syllables)
+            syllable_labels[block] = syllable_categories.codes
+
+        elif match_filename(file, recording_format, ['audio']):
+            block = extract_block_id(file)
+            if block not in intervals:
+                continue
+            if block in audio_onset:
+                warnings.warn(
+                    f'Found multiple audio files for block {block}, skipping {file}.')
+                continue
+            file_path = os.path.join(params.data_dir, file)
+            dataset = np.load(file_path)
+            try:
+                audio_data = dataset['data']
+                audio_sf = int(dataset['sf'])
+            except KeyError:
+                raise KeyError(
+                    f"Expected keys 'data' and 'sf' not found in {file}. "
+                    f"Existing keys {list(dataset.keys())}.")
+
+            block_intervals = intervals[block]
+            required_cols = {'start', 'end', 'syllable', 'tone'}
+            if not required_cols.issubset(block_intervals.columns):
+                raise ValueError(
+                    f"Intervals for block {block} must contain columns {required_cols}. "
+                    f"Available: {list(block_intervals.columns)}")
+            block_intervals = block_intervals.sort_values('start').reset_index(drop=True)
+            audio_onset[block] = []
+            audio_pre[block] = []
+            prev_end = 0.0
+            for _, row in block_intervals.iterrows():
+                onset_time = row[onset_pos]
+                start_idx = int(onset_time * audio_sf)
+                length_idx = int(sample_length * audio_sf)
+                end_idx = start_idx + length_idx
+                if end_idx > audio_data.shape[1]:
+                    raise ValueError(
+                        f"Requested sample exceeds audio data for block {block}.")
+                audio_onset[block].append(audio_data[0, start_idx:end_idx].flatten())
+
+                pre_end = start_idx
+                pre_start_time = max(onset_time - pre_length, prev_end)
+                pre_start_idx = int(pre_start_time * audio_sf)
+                pre_seg = audio_data[0, pre_start_idx:pre_end].flatten()
+                desired = int(pre_length * audio_sf)
+                if pre_seg.shape[0] < desired:
+                    pad = np.zeros(desired - pre_seg.shape[0])
+                    pre_seg = np.concatenate([pad, pre_seg])
+                audio_pre[block].append(pre_seg[-desired:])
+                prev_end = row['end']
+            audio_onset[block] = np.array(audio_onset[block])
+            audio_pre[block] = np.array(audio_pre[block])
+
+    block_ids = ecog_onset.keys()
+    if block_ids != audio_onset.keys():
+        raise ValueError(
+            "Mismatch between ECoG and audio blocks."
+        )
+    all_ecog_onset = np.concatenate([ecog_onset[b] for b in block_ids], axis=0)
+    all_ecog_pre = np.concatenate([ecog_pre[b] for b in block_ids], axis=0)
+    all_audio_onset = np.concatenate([audio_onset[b] for b in block_ids], axis=0)
+    all_audio_pre = np.concatenate([audio_pre[b] for b in block_ids], axis=0)
+    all_syllable = np.concatenate([syllable_labels[b] for b in block_ids], axis=0)
+    all_tone = np.concatenate([tone_labels[b] for b in block_ids], axis=0)
+    min_label = np.min(all_tone)
+    if min_label > 0:
+        all_tone -= min_label
+
+    output = {
+        'ecog_onset': all_ecog_onset,
+        'ecog_pre': all_ecog_pre,
+        'ecog_sf': ecog_sf,
+        'audio_onset': all_audio_onset,
+        'audio_pre': all_audio_pre,
+        'audio_sf': audio_sf,
+        'syllable': all_syllable,
+        'tone': all_tone,
+    }
+    if params.output_path is not None:
+        np.savez(params.output_path, **output)
+        print(f"Samples saved to {params.output_path}")
+    return output


### PR DESCRIPTION
## Summary
- add sample collection module to extract paired speech-onset and pre-onset ECoG/audio segments while avoiding overlap with previous speech
- include channel selection module using paired t-tests between onset and pre-onset signals

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a562b962e883299dfec080e1984282